### PR TITLE
Month string fixes, header label text alignment and example of usage

### DIFF
--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView.xcodeproj/project.pbxproj
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView.xcodeproj/project.pbxproj
@@ -1,0 +1,442 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		B007E7871F7394E800C6CC0B /* FSCalendar+Deprecated.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7661F7394E700C6CC0B /* FSCalendar+Deprecated.m */; };
+		B007E7881F7394E800C6CC0B /* FSCalendar.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7681F7394E700C6CC0B /* FSCalendar.m */; };
+		B007E7891F7394E800C6CC0B /* FSCalendarAppearance.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E76A1F7394E700C6CC0B /* FSCalendarAppearance.m */; };
+		B007E78A1F7394E800C6CC0B /* FSCalendarCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E76C1F7394E700C6CC0B /* FSCalendarCalculator.m */; };
+		B007E78B1F7394E800C6CC0B /* FSCalendarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E76E1F7394E700C6CC0B /* FSCalendarCell.m */; };
+		B007E78C1F7394E800C6CC0B /* FSCalendarCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7701F7394E700C6CC0B /* FSCalendarCollectionView.m */; };
+		B007E78D1F7394E800C6CC0B /* FSCalendarCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7721F7394E700C6CC0B /* FSCalendarCollectionViewLayout.m */; };
+		B007E78E1F7394E800C6CC0B /* FSCalendarConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7741F7394E700C6CC0B /* FSCalendarConstants.m */; };
+		B007E78F1F7394E800C6CC0B /* FSCalendarDelegationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7761F7394E700C6CC0B /* FSCalendarDelegationFactory.m */; };
+		B007E7901F7394E800C6CC0B /* FSCalendarDelegationProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7781F7394E700C6CC0B /* FSCalendarDelegationProxy.m */; };
+		B007E7911F7394E800C6CC0B /* FSCalendarExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E77B1F7394E700C6CC0B /* FSCalendarExtensions.m */; };
+		B007E7921F7394E800C6CC0B /* FSCalendarHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E77D1F7394E700C6CC0B /* FSCalendarHeaderView.m */; };
+		B007E7931F7394E800C6CC0B /* FSCalendarScopeHandle.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E77F1F7394E700C6CC0B /* FSCalendarScopeHandle.m */; };
+		B007E7941F7394E800C6CC0B /* FSCalendarStickyHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7811F7394E700C6CC0B /* FSCalendarStickyHeader.m */; };
+		B007E7951F7394E800C6CC0B /* FSCalendarTransitionCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7831F7394E700C6CC0B /* FSCalendarTransitionCoordinator.m */; };
+		B007E7961F7394E800C6CC0B /* FSCalendarWeekdayView.m in Sources */ = {isa = PBXBuildFile; fileRef = B007E7851F7394E700C6CC0B /* FSCalendarWeekdayView.m */; };
+		B007E7971F7394E800C6CC0B /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B007E7861F7394E700C6CC0B /* Info.plist */; };
+		B06575BF1F7289F700174B4B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06575BE1F7289F700174B4B /* AppDelegate.swift */; };
+		B06575C11F7289F700174B4B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06575C01F7289F700174B4B /* ViewController.swift */; };
+		B06575C41F7289F700174B4B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B06575C21F7289F700174B4B /* Main.storyboard */; };
+		B06575C61F7289F700174B4B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B06575C51F7289F700174B4B /* Assets.xcassets */; };
+		B06575C91F7289F700174B4B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B06575C71F7289F700174B4B /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		B007E7661F7394E700C6CC0B /* FSCalendar+Deprecated.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FSCalendar+Deprecated.m"; sourceTree = "<group>"; };
+		B007E7671F7394E700C6CC0B /* FSCalendar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendar.h; sourceTree = "<group>"; };
+		B007E7681F7394E700C6CC0B /* FSCalendar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendar.m; sourceTree = "<group>"; };
+		B007E7691F7394E700C6CC0B /* FSCalendarAppearance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarAppearance.h; sourceTree = "<group>"; };
+		B007E76A1F7394E700C6CC0B /* FSCalendarAppearance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarAppearance.m; sourceTree = "<group>"; };
+		B007E76B1F7394E700C6CC0B /* FSCalendarCalculator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarCalculator.h; sourceTree = "<group>"; };
+		B007E76C1F7394E700C6CC0B /* FSCalendarCalculator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarCalculator.m; sourceTree = "<group>"; };
+		B007E76D1F7394E700C6CC0B /* FSCalendarCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarCell.h; sourceTree = "<group>"; };
+		B007E76E1F7394E700C6CC0B /* FSCalendarCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarCell.m; sourceTree = "<group>"; };
+		B007E76F1F7394E700C6CC0B /* FSCalendarCollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarCollectionView.h; sourceTree = "<group>"; };
+		B007E7701F7394E700C6CC0B /* FSCalendarCollectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarCollectionView.m; sourceTree = "<group>"; };
+		B007E7711F7394E700C6CC0B /* FSCalendarCollectionViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarCollectionViewLayout.h; sourceTree = "<group>"; };
+		B007E7721F7394E700C6CC0B /* FSCalendarCollectionViewLayout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarCollectionViewLayout.m; sourceTree = "<group>"; };
+		B007E7731F7394E700C6CC0B /* FSCalendarConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarConstants.h; sourceTree = "<group>"; };
+		B007E7741F7394E700C6CC0B /* FSCalendarConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarConstants.m; sourceTree = "<group>"; };
+		B007E7751F7394E700C6CC0B /* FSCalendarDelegationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarDelegationFactory.h; sourceTree = "<group>"; };
+		B007E7761F7394E700C6CC0B /* FSCalendarDelegationFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarDelegationFactory.m; sourceTree = "<group>"; };
+		B007E7771F7394E700C6CC0B /* FSCalendarDelegationProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarDelegationProxy.h; sourceTree = "<group>"; };
+		B007E7781F7394E700C6CC0B /* FSCalendarDelegationProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarDelegationProxy.m; sourceTree = "<group>"; };
+		B007E7791F7394E700C6CC0B /* FSCalendarDynamicHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarDynamicHeader.h; sourceTree = "<group>"; };
+		B007E77A1F7394E700C6CC0B /* FSCalendarExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarExtensions.h; sourceTree = "<group>"; };
+		B007E77B1F7394E700C6CC0B /* FSCalendarExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarExtensions.m; sourceTree = "<group>"; };
+		B007E77C1F7394E700C6CC0B /* FSCalendarHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarHeaderView.h; sourceTree = "<group>"; };
+		B007E77D1F7394E700C6CC0B /* FSCalendarHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarHeaderView.m; sourceTree = "<group>"; };
+		B007E77E1F7394E700C6CC0B /* FSCalendarScopeHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarScopeHandle.h; sourceTree = "<group>"; };
+		B007E77F1F7394E700C6CC0B /* FSCalendarScopeHandle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarScopeHandle.m; sourceTree = "<group>"; };
+		B007E7801F7394E700C6CC0B /* FSCalendarStickyHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarStickyHeader.h; sourceTree = "<group>"; };
+		B007E7811F7394E700C6CC0B /* FSCalendarStickyHeader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarStickyHeader.m; sourceTree = "<group>"; };
+		B007E7821F7394E700C6CC0B /* FSCalendarTransitionCoordinator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarTransitionCoordinator.h; sourceTree = "<group>"; };
+		B007E7831F7394E700C6CC0B /* FSCalendarTransitionCoordinator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarTransitionCoordinator.m; sourceTree = "<group>"; };
+		B007E7841F7394E700C6CC0B /* FSCalendarWeekdayView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSCalendarWeekdayView.h; sourceTree = "<group>"; };
+		B007E7851F7394E700C6CC0B /* FSCalendarWeekdayView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FSCalendarWeekdayView.m; sourceTree = "<group>"; };
+		B007E7861F7394E700C6CC0B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B06575BB1F7289F700174B4B /* Example-CustomizableHeaderView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example-CustomizableHeaderView.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B06575BE1F7289F700174B4B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B06575C01F7289F700174B4B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B06575C31F7289F700174B4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		B06575C51F7289F700174B4B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B06575C81F7289F700174B4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		B06575CA1F7289F700174B4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B06576041F728AE700174B4B /* Example-CustomizableHeaderView-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Example-CustomizableHeaderView-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		B06575B81F7289F700174B4B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		B007E7651F7394E700C6CC0B /* FSCalendar */ = {
+			isa = PBXGroup;
+			children = (
+				B007E7661F7394E700C6CC0B /* FSCalendar+Deprecated.m */,
+				B007E7671F7394E700C6CC0B /* FSCalendar.h */,
+				B007E7681F7394E700C6CC0B /* FSCalendar.m */,
+				B007E7691F7394E700C6CC0B /* FSCalendarAppearance.h */,
+				B007E76A1F7394E700C6CC0B /* FSCalendarAppearance.m */,
+				B007E76B1F7394E700C6CC0B /* FSCalendarCalculator.h */,
+				B007E76C1F7394E700C6CC0B /* FSCalendarCalculator.m */,
+				B007E76D1F7394E700C6CC0B /* FSCalendarCell.h */,
+				B007E76E1F7394E700C6CC0B /* FSCalendarCell.m */,
+				B007E76F1F7394E700C6CC0B /* FSCalendarCollectionView.h */,
+				B007E7701F7394E700C6CC0B /* FSCalendarCollectionView.m */,
+				B007E7711F7394E700C6CC0B /* FSCalendarCollectionViewLayout.h */,
+				B007E7721F7394E700C6CC0B /* FSCalendarCollectionViewLayout.m */,
+				B007E7731F7394E700C6CC0B /* FSCalendarConstants.h */,
+				B007E7741F7394E700C6CC0B /* FSCalendarConstants.m */,
+				B007E7751F7394E700C6CC0B /* FSCalendarDelegationFactory.h */,
+				B007E7761F7394E700C6CC0B /* FSCalendarDelegationFactory.m */,
+				B007E7771F7394E700C6CC0B /* FSCalendarDelegationProxy.h */,
+				B007E7781F7394E700C6CC0B /* FSCalendarDelegationProxy.m */,
+				B007E7791F7394E700C6CC0B /* FSCalendarDynamicHeader.h */,
+				B007E77A1F7394E700C6CC0B /* FSCalendarExtensions.h */,
+				B007E77B1F7394E700C6CC0B /* FSCalendarExtensions.m */,
+				B007E77C1F7394E700C6CC0B /* FSCalendarHeaderView.h */,
+				B007E77D1F7394E700C6CC0B /* FSCalendarHeaderView.m */,
+				B007E77E1F7394E700C6CC0B /* FSCalendarScopeHandle.h */,
+				B007E77F1F7394E700C6CC0B /* FSCalendarScopeHandle.m */,
+				B007E7801F7394E700C6CC0B /* FSCalendarStickyHeader.h */,
+				B007E7811F7394E700C6CC0B /* FSCalendarStickyHeader.m */,
+				B007E7821F7394E700C6CC0B /* FSCalendarTransitionCoordinator.h */,
+				B007E7831F7394E700C6CC0B /* FSCalendarTransitionCoordinator.m */,
+				B007E7841F7394E700C6CC0B /* FSCalendarWeekdayView.h */,
+				B007E7851F7394E700C6CC0B /* FSCalendarWeekdayView.m */,
+				B007E7861F7394E700C6CC0B /* Info.plist */,
+			);
+			name = FSCalendar;
+			path = ../FSCalendar;
+			sourceTree = "<group>";
+		};
+		B06575B21F7289F700174B4B = {
+			isa = PBXGroup;
+			children = (
+				B007E7651F7394E700C6CC0B /* FSCalendar */,
+				B06575BD1F7289F700174B4B /* Example-CustomizableHeaderView */,
+				B06575BC1F7289F700174B4B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		B06575BC1F7289F700174B4B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B06575BB1F7289F700174B4B /* Example-CustomizableHeaderView.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B06575BD1F7289F700174B4B /* Example-CustomizableHeaderView */ = {
+			isa = PBXGroup;
+			children = (
+				B06576041F728AE700174B4B /* Example-CustomizableHeaderView-Bridging-Header.h */,
+				B06575BE1F7289F700174B4B /* AppDelegate.swift */,
+				B06575C01F7289F700174B4B /* ViewController.swift */,
+				B06575C21F7289F700174B4B /* Main.storyboard */,
+				B06575C51F7289F700174B4B /* Assets.xcassets */,
+				B06575C71F7289F700174B4B /* LaunchScreen.storyboard */,
+				B06575CA1F7289F700174B4B /* Info.plist */,
+			);
+			path = "Example-CustomizableHeaderView";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		B06575BA1F7289F700174B4B /* Example-CustomizableHeaderView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B06575CD1F7289F700174B4B /* Build configuration list for PBXNativeTarget "Example-CustomizableHeaderView" */;
+			buildPhases = (
+				B06575B71F7289F700174B4B /* Sources */,
+				B06575B81F7289F700174B4B /* Frameworks */,
+				B06575B91F7289F700174B4B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Example-CustomizableHeaderView";
+			productName = "Example-CustomizableHeaderView";
+			productReference = B06575BB1F7289F700174B4B /* Example-CustomizableHeaderView.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		B06575B31F7289F700174B4B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0900;
+				LastUpgradeCheck = 0900;
+				ORGANIZATIONNAME = "Andrzej Spiess";
+				TargetAttributes = {
+					B06575BA1F7289F700174B4B = {
+						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = B06575B61F7289F700174B4B /* Build configuration list for PBXProject "Example-CustomizableHeaderView" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = B06575B21F7289F700174B4B;
+			productRefGroup = B06575BC1F7289F700174B4B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B06575BA1F7289F700174B4B /* Example-CustomizableHeaderView */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		B06575B91F7289F700174B4B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B007E7971F7394E800C6CC0B /* Info.plist in Resources */,
+				B06575C91F7289F700174B4B /* LaunchScreen.storyboard in Resources */,
+				B06575C61F7289F700174B4B /* Assets.xcassets in Resources */,
+				B06575C41F7289F700174B4B /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		B06575B71F7289F700174B4B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B007E7921F7394E800C6CC0B /* FSCalendarHeaderView.m in Sources */,
+				B06575C11F7289F700174B4B /* ViewController.swift in Sources */,
+				B007E7931F7394E800C6CC0B /* FSCalendarScopeHandle.m in Sources */,
+				B007E78B1F7394E800C6CC0B /* FSCalendarCell.m in Sources */,
+				B007E78F1F7394E800C6CC0B /* FSCalendarDelegationFactory.m in Sources */,
+				B007E7901F7394E800C6CC0B /* FSCalendarDelegationProxy.m in Sources */,
+				B007E7941F7394E800C6CC0B /* FSCalendarStickyHeader.m in Sources */,
+				B007E7951F7394E800C6CC0B /* FSCalendarTransitionCoordinator.m in Sources */,
+				B007E7871F7394E800C6CC0B /* FSCalendar+Deprecated.m in Sources */,
+				B007E78D1F7394E800C6CC0B /* FSCalendarCollectionViewLayout.m in Sources */,
+				B007E7961F7394E800C6CC0B /* FSCalendarWeekdayView.m in Sources */,
+				B007E78A1F7394E800C6CC0B /* FSCalendarCalculator.m in Sources */,
+				B007E7881F7394E800C6CC0B /* FSCalendar.m in Sources */,
+				B007E78E1F7394E800C6CC0B /* FSCalendarConstants.m in Sources */,
+				B06575BF1F7289F700174B4B /* AppDelegate.swift in Sources */,
+				B007E7891F7394E800C6CC0B /* FSCalendarAppearance.m in Sources */,
+				B007E78C1F7394E800C6CC0B /* FSCalendarCollectionView.m in Sources */,
+				B007E7911F7394E800C6CC0B /* FSCalendarExtensions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		B06575C21F7289F700174B4B /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B06575C31F7289F700174B4B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		B06575C71F7289F700174B4B /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B06575C81F7289F700174B4B /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		B06575CB1F7289F700174B4B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		B06575CC1F7289F700174B4B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B06575CE1F7289F700174B4B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Example-CustomizableHeaderView/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "AS.Example-CustomizableHeaderView";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Example-CustomizableHeaderView/Example-CustomizableHeaderView-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		B06575CF1F7289F700174B4B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "Example-CustomizableHeaderView/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "AS.Example-CustomizableHeaderView";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Example-CustomizableHeaderView/Example-CustomizableHeaderView-Bridging-Header.h";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		B06575B61F7289F700174B4B /* Build configuration list for PBXProject "Example-CustomizableHeaderView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B06575CB1F7289F700174B4B /* Debug */,
+				B06575CC1F7289F700174B4B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B06575CD1F7289F700174B4B /* Build configuration list for PBXNativeTarget "Example-CustomizableHeaderView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B06575CE1F7289F700174B4B /* Debug */,
+				B06575CF1F7289F700174B4B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = B06575B31F7289F700174B4B /* Project object */;
+}

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Example-CustomizableHeaderView.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/AppDelegate.swift
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Example-CustomizableHeaderView
+//
+//  Created by Andrzej Spiess on 20.09.2017.
+//  Copyright © 2017 Andrzej Spiess. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Base.lproj/LaunchScreen.storyboard
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Base.lproj/Main.storyboard
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Base.lproj/Main.storyboard
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Example_CustomizableHeaderView" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oan-IV-fRe" customClass="FSCalendar">
+                                <rect key="frame" x="16" y="20" width="343" height="647"/>
+                                <color key="backgroundColor" red="0.0" green="0.086274509803921567" blue="0.30196078431372547" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" red="0.0" green="0.086274509803921567" blue="0.30196078431372547" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="oan-IV-fRe" secondAttribute="trailing" constant="16" id="NOW-Id-Odf"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="oan-IV-fRe" secondAttribute="bottom" id="Ndo-sj-iLn"/>
+                            <constraint firstItem="oan-IV-fRe" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="oBG-bs-QWx"/>
+                            <constraint firstItem="oan-IV-fRe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="yan-bL-tHy"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                    <connections>
+                        <outlet property="calendarView" destination="oan-IV-fRe" id="uBL-9f-TBw"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Example-CustomizableHeaderView-Bridging-Header.h
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Example-CustomizableHeaderView-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "FSCalendar.h"

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Info.plist
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Example-CustomizableHeaderView/Example-CustomizableHeaderView/ViewController.swift
+++ b/Example-CustomizableHeaderView/Example-CustomizableHeaderView/ViewController.swift
@@ -1,0 +1,164 @@
+//
+//  ViewController.swift
+//  IFSCalendarFSCalendar
+//
+//  Created by Andrzej Spiess on 17.09.2017.
+//  Copyright © 2017 eSky. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+    
+    @IBOutlet weak var calendarView: FSCalendar!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        calendarView.scrollDirection = .vertical
+        calendarView.locale = Locale(identifier: "PL")
+        calendarView.placeholderType = .none
+        
+        calendarView.register(IFSCalendarCell.self, forCellReuseIdentifier: "IFSCell")
+        
+        // MARK: Configure Sizes
+        
+        calendarView.rowHeight = 50
+        calendarView.headerHeight = 60
+        calendarView.weekdayHeight = 0
+        calendarView.pagingEnabled = false
+        
+        // MARK: Configure Appearance
+        
+        calendarView.appearance.headerTitleColor = UIColor.white
+        calendarView.appearance.headerTitleFont = UIFont.boldSystemFont(ofSize: 20)
+        calendarView.appearance.headerTitleTextAlignment = .left
+        calendarView.appearance.headerDateFormat = "MMMM"
+        calendarView.appearance.bottomBorderLineColor = UIColor.clear
+        
+        calendarView.delegate = self
+        calendarView.dataSource = self
+        
+    }
+}
+
+
+// MARK: FSCalendarDataSource
+
+extension ViewController: FSCalendarDataSource {
+    
+    func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {
+        return calendar.dequeueReusableCell(withIdentifier: "IFSCell", for: date, at: position)
+    }
+    
+    func calendar(_ calendar: FSCalendar, willDisplay cell: FSCalendarCell, for date: Date, at monthPosition: FSCalendarMonthPosition) {
+        (cell as? IFSCalendarCell)?.isMarked = calendar.selectedDates.contains(date)
+    }
+    
+}
+
+// MARK: FSCalendarDelegateAppearance & FSCalendarDelegate
+
+extension ViewController: FSCalendarDelegateAppearance {
+    
+    // MARK: Delegate
+    
+    func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
+        return monthPosition == FSCalendarMonthPosition.current
+    }
+    
+    // MARK: Appearance
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillDefaultColorFor date: Date) -> UIColor? {
+        return UIColor(red: 7/255.0, green: 117/255.0, blue: 226/255.0, alpha: 0.2)
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, fillSelectionColorFor date: Date) -> UIColor? {
+        return UIColor(red: 226/255.0, green: 7/255.0, blue: 107/255.0, alpha: 1)
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleDefaultColorFor date: Date) -> UIColor? {
+        return UIColor(red: 255/255.0, green: 255/255.0, blue: 255/255.0, alpha: 0.5)
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleSelectionColorFor date: Date) -> UIColor? {
+        return UIColor.white
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, borderDefaultColorFor date: Date) -> UIColor? {
+        return UIColor.clear
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, borderSelectionColorFor date: Date) -> UIColor? {
+        return UIColor.white
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleOffsetFor date: Date) -> CGPoint {
+        return CGPoint(x: 0, y: 3)
+    }
+}
+
+class IFSCalendarCell: FSCalendarCell {
+    
+    override var isSelected: Bool {
+        didSet {
+            isMarked = isSelected
+        }
+    }
+    
+    var isMarked: Bool = false {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+    
+    private func mark() {
+        defaultShapeLayer.fillColor = UIColor(red: 226/255.0, green: 7/255.0, blue: 107/255.0, alpha: 1).cgColor
+        defaultShapeLayer.lineWidth = 4
+        defaultShapeLayer.strokeColor = UIColor.white.cgColor
+        
+        
+        self.layer.addSublayer(titleLabel.layer)
+    }
+    
+    private func unmark() {
+        defaultShapeLayer.fillColor = UIColor(red: 7/255.0, green: 117/255.0, blue: 226/255.0, alpha: 0.2).cgColor
+        defaultShapeLayer.lineWidth = 0
+        defaultShapeLayer.strokeColor = nil
+        
+        
+        self.layer.addSublayer(titleLabel.layer)
+    }
+    
+    required init!(coder aDecoder: NSCoder!) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    var defaultShapeLayer: CAShapeLayer!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        shapeLayer.isHidden = true
+        
+        let defaultShapeLayer = CAShapeLayer()
+        defaultShapeLayer.fillColor = UIColor(red: 7/255.0, green: 117/255.0, blue: 226/255.0, alpha: 0.2).cgColor
+        
+        defaultShapeLayer.path = UIBezierPath(roundedRect: self.bounds.insetBy(dx: 5, dy: 5), byRoundingCorners: [.allCorners], cornerRadii: CGSize(width: 5, height: 5)).cgPath
+        
+        
+        self.defaultShapeLayer = defaultShapeLayer
+        self.layer.insertSublayer(defaultShapeLayer, below: self.titleLabel!.layer)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        if isMarked {
+            mark()
+        } else {
+            unmark()
+        }
+    }
+}
+

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -226,13 +226,13 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
     if (!FSCalendarInAppExtension) {
         
         UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
-        view.backgroundColor = FSCalendarStandardLineColor;
+        view.backgroundColor = _appearance.topBorderLineColor;
         view.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin; // Stick to top
         [self addSubview:view];
         self.topBorder = view;
         
         view = [[UIView alloc] initWithFrame:CGRectZero];
-        view.backgroundColor = FSCalendarStandardLineColor;
+        view.backgroundColor = _appearance.bottomBorderLineColor;
         view.autoresizingMask = UIViewAutoresizingFlexibleTopMargin; // Stick to bottom
         [self addSubview:view];
         self.bottomBorder = view;
@@ -363,7 +363,9 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
         }
         _collectionView.fs_height = FSCalendarHalfFloor(_collectionView.fs_height);
         _topBorder.frame = CGRectMake(0, -1, self.fs_width, 1);
+        _topBorder.backgroundColor = _appearance.topBorderLineColor;
         _bottomBorder.frame = CGRectMake(0, self.fs_height, self.fs_width, 1);
+        _bottomBorder.backgroundColor = _appearance.bottomBorderLineColor;
         _scopeHandle.fs_bottom = _bottomBorder.fs_top;
         
     }

--- a/FSCalendar/FSCalendarAppearance.h
+++ b/FSCalendar/FSCalendarAppearance.h
@@ -206,6 +206,22 @@ typedef NS_OPTIONS(NSUInteger, FSCalendarCaseOptions) {
  */
 @property (assign, nonatomic) FSCalendarSeparators separators;
 
+/**
+ * The text alignment of the header title.
+ * Default is NSTextAlignmentCenter.
+ */
+@property (assign, nonatomic) NSTextAlignment headerTitleTextAlignment;
+
+/**
+ * The line color of the top border view.
+ */
+@property (strong, nonatomic) UIColor  *topBorderLineColor;
+
+/**
+ * The line color of the bottom border view.
+ */
+@property (strong, nonatomic) UIColor  *bottomBorderLineColor;
+
 #if TARGET_INTERFACE_BUILDER
 
 // For preview only

--- a/FSCalendar/FSCalendarAppearance.m
+++ b/FSCalendar/FSCalendarAppearance.m
@@ -71,6 +71,10 @@
         
         _borderColors = [NSMutableDictionary dictionaryWithCapacity:2];
         
+        _headerTitleTextAlignment = NSTextAlignmentCenter;
+        _topBorderLineColor = FSCalendarStandardLineColor;
+        _bottomBorderLineColor = FSCalendarStandardLineColor;
+        
 #if TARGET_INTERFACE_BUILDER
         _fakeEventDots = YES;
 #endif

--- a/FSCalendar/FSCalendarStickyHeader.m
+++ b/FSCalendar/FSCalendarStickyHeader.m
@@ -70,7 +70,6 @@
     
     _bottomBorder.frame = CGRectMake(0, _contentView.fs_height-weekdayHeight-weekdayMargin*2, _contentView.fs_width, 1.0);
     _titleLabel.frame = CGRectMake(0, _bottomBorder.fs_bottom-titleHeight-weekdayMargin, titleWidth,titleHeight);
-    
 }
 
 #pragma mark - Properties
@@ -90,6 +89,9 @@
 {
     _titleLabel.font = self.calendar.appearance.headerTitleFont;
     _titleLabel.textColor = self.calendar.appearance.headerTitleColor;
+    _titleLabel.textAlignment = _calendar.appearance.headerTitleTextAlignment;
+    _bottomBorder.backgroundColor = _calendar.appearance.bottomBorderLineColor;
+
     [self.weekdayView configureAppearance];
 }
 
@@ -97,8 +99,12 @@
 {
     _month = month;
     _calendar.formatter.dateFormat = self.calendar.appearance.headerDateFormat;
+    
+    NSInteger monthNumber = [_calendar.formatter.calendar component:NSCalendarUnitMonth fromDate:month];
+    _calendar.formatter.formattingContext = NSFormattingContextBeginningOfSentence;
+    NSString *text = _calendar.formatter.standaloneMonthSymbols[monthNumber-1];
+    
     BOOL usesUpperCase = (self.calendar.appearance.caseOptions & 15) == FSCalendarCaseOptionsHeaderUsesUpperCase;
-    NSString *text = [_calendar.formatter stringFromDate:_month];
     text = usesUpperCase ? text.uppercaseString : text;
     self.titleLabel.text = text;
 }

--- a/FSCalendar/FSCalendarTransitionCoordinator.m
+++ b/FSCalendar/FSCalendarTransitionCoordinator.m
@@ -20,7 +20,7 @@
 - (void)performTransitionCompletionAnimated:(BOOL)animated;
 - (void)performTransitionCompletion:(FSCalendarTransition)transition animated:(BOOL)animated;
 
-- (void)performAlphaAnimationFrom:(CGFloat)fromAlpha to:(CGFloat)toAlpha duration:(CGFloat)duration exception:(NSInteger)exception completion:(void(^)())completion;
+- (void)performAlphaAnimationFrom:(CGFloat)fromAlpha to:(CGFloat)toAlpha duration:(CGFloat)duration exception:(NSInteger)exception completion:(void(^)(void))completion;
 - (void)performForwardTransition:(FSCalendarTransition)transition fromProgress:(CGFloat)progress;
 - (void)performBackwardTransition:(FSCalendarTransition)transition fromProgress:(CGFloat)progress;
 - (void)performAlphaAnimationWithProgress:(CGFloat)progress;
@@ -674,7 +674,7 @@
     }
 }
 
-- (void)performAlphaAnimationFrom:(CGFloat)fromAlpha to:(CGFloat)toAlpha duration:(CGFloat)duration exception:(NSInteger)exception completion:(void(^)())completion;
+- (void)performAlphaAnimationFrom:(CGFloat)fromAlpha to:(CGFloat)toAlpha duration:(CGFloat)duration exception:(NSInteger)exception completion:(void(^)(void))completion;
 {
     [self.calendar.visibleCells enumerateObjectsUsingBlock:^(FSCalendarCell *cell, NSUInteger idx, BOOL *stop) {
         if (CGRectContainsPoint(self.collectionView.bounds, cell.center)) {


### PR DESCRIPTION
Month name string is now taken from standaloneMonths with formattingContext NSFormattingContextBeginningOfSentence fixing month name forms in languages like polish. Added bottom and top border lines colors and header label text alignment property to appearance.